### PR TITLE
Bump http-proxy-middleware in /front-end

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -12,7 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",
-        "http-proxy-middleware": "^3.0.3",
+        "http-proxy-middleware": "^3.0.5",
         "minimist": "^1.2.8",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.47",
@@ -8635,9 +8635,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.3.tgz",
-      "integrity": "sha512-usY0HG5nyDUwtqpiZdETNbmKtw3QQ1jwYFZ9wi5iHzX2BcILwQKtYDJPo7XHTsu5Z0B2Hj3W9NNnbd+AjFWjqg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.15",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -8,7 +8,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
-    "http-proxy-middleware": "^3.0.3",
+    "http-proxy-middleware": "^3.0.5",
     "minimist": "^1.2.8",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.47",


### PR DESCRIPTION
Bumps  and [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware). These dependencies needed to be updated together.

Updates `http-proxy-middleware` from 3.0.3 to 3.0.5
- [Release notes](https://github.com/chimurai/http-proxy-middleware/releases)
- [Changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)
- [Commits](https://github.com/chimurai/http-proxy-middleware/compare/v3.0.3...v3.0.5)

Updates `http-proxy-middleware` from 2.0.7 to 3.0.5
- [Release notes](https://github.com/chimurai/http-proxy-middleware/releases)
- [Changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)
- [Commits](https://github.com/chimurai/http-proxy-middleware/compare/v3.0.3...v3.0.5)

---
updated-dependencies:
- dependency-name: http-proxy-middleware dependency-version: 3.0.5 dependency-type: direct:production
- dependency-name: http-proxy-middleware dependency-version: 3.0.5 dependency-type: direct:production ...